### PR TITLE
Add generic data

### DIFF
--- a/CoreApiTemplate/Data/GenericData.cs
+++ b/CoreApiTemplate/Data/GenericData.cs
@@ -1,0 +1,10 @@
+﻿using CoreApiTemplate.Integrations.Persistence;
+using MySqlConnector;
+
+namespace CoreApiTemplate.Data;
+
+public class GenericData<T>(MySqlConnection context, IConfiguration configuration, string schemaName, string database, string keyColumnName) : BaseSqlDataContext<T>(context,
+    configuration,
+    schemaName: schemaName,
+    database: database,
+    keyColumnName: keyColumnName), IDataContext<T>;

--- a/CoreApiTemplate/Integrations/Persistence/DataContextFactory.cs
+++ b/CoreApiTemplate/Integrations/Persistence/DataContextFactory.cs
@@ -1,14 +1,25 @@
-﻿using CoreApiTemplate.Exceptions;
+﻿using CoreApiTemplate.Data;
+using CoreApiTemplate.Exceptions;
+using MySqlConnector;
 
 namespace CoreApiTemplate.Integrations.Persistence;
 
-public class DataContextFactory(IServiceProvider serviceProvider) : IDataContextFactory
+public class DataContextFactory(IServiceProvider serviceProvider, MySqlConnection context,
+    IConfiguration configuration) : IDataContextFactory
 {
     public IDataContext<T> Get<T>() where T : class
     {
         var service = serviceProvider.GetService(typeof(IDataContext<T>));
 
-        if (service == null) throw new DataContextFactoryException(typeof(T).Name);
+        if (service == null)
+        {
+            var attributes = typeof(T).GetCustomAttributes(
+                typeof(SqlDataAttribute), true
+            ).FirstOrDefault() as SqlDataAttribute ?? throw new DataContextFactoryException(typeof(T).Name);
+
+            service = new GenericData<T>(context, configuration, attributes.SchemaName, attributes.Database,
+                attributes.KeyColumnName);
+        }
 
         return (IDataContext<T>) service;
     }

--- a/CoreApiTemplate/Integrations/Persistence/SqlDataAttribute.cs
+++ b/CoreApiTemplate/Integrations/Persistence/SqlDataAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace CoreApiTemplate.Integrations.Persistence;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class SqlDataAttribute(string schemaName, string database, string keyColumnName) : Attribute
+{
+    public string SchemaName { get; set; } = schemaName;
+
+    public string Database { get; set; } = database;
+
+    public string KeyColumnName { get; set; } = keyColumnName;
+}

--- a/CoreApiTemplate/IoC/DataServiceInjection.cs
+++ b/CoreApiTemplate/IoC/DataServiceInjection.cs
@@ -18,6 +18,7 @@ public class DataServiceInjection
 
         foreach (var instance in instances)
         {
+            if(instance.Name == "GenericData`1") continue;
             var definition = instance.GetInterfaces().First(item =>
                 item.IsGenericType && item.GetGenericTypeDefinition() == typeof(IDataContext<>));
             serviceCollection.AddSingleton(definition, instance);

--- a/CoreApiTemplate/Models/Generic.cs
+++ b/CoreApiTemplate/Models/Generic.cs
@@ -1,0 +1,8 @@
+﻿using CoreApiTemplate.Integrations.Persistence;
+
+namespace CoreApiTemplate.Models;
+[SqlData("", "", "")]
+public class Generic
+{
+    
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There's a few limitations to be aware of:
 `BaseSqlDataContext` uses reflection to construct sql queries from classes and must data queries will end up using it so 
 keep that in mind.
 - Where data is to be persisted, there needs to be a model and a data class which is okay for the project's intended use 
-but may get cumbersome over time.
+but may get cumbersome over time but to get around this `SqlDataAttribute` can be used on the model class.
 - Alot of services are singleton given it's only ever going to be local development
 
 
@@ -36,10 +36,17 @@ implementations - Again this is really to save time and make creating a new mode
 `IDataContext<T>` to make creating a new model as easy as possible.
 
 ### Data classes
-A new model can be created by a new class implementing `IDataContext<T>` which defines most core interactions with persisting data.
+A new model can be created by two methods: 
+
+1) A new class implementing `IDataContext<T>` which defines most core interactions with persisting data.
 You can also inherit base contexts that implement most/all the methods for the data class to work. The reason i've not made
 it part of the interface is because i have an intention to not limit the persistence to sql services therefore the base 
 can be interchanged.
+
+2) Using `SqlDataAttribute` on the model for data structures that don't require any overrides for their implementation.
+This will create a generic class implementing `IDataContext<T>` for you to reduce the overhead further
+
+
 
 ## Future work
 Check out [the project page](https://github.com/lukedev20/CoreApiTemplate/projects). I can't make any promises on how long 


### PR DESCRIPTION
Allow `SqlDataAttribute` on the model for data structures that don't require any overrides for their implementation.
This will create a generic class implementing `IDataContext<T>` to reduce the overhead of creating a new model